### PR TITLE
Reassess Agency

### DIFF
--- a/Lexicon.md
+++ b/Lexicon.md
@@ -15,12 +15,9 @@
 * __System__: An __Object__ composed of correlated member __Objects__.
 * __Model__: A __System__ that represents another __System__. It can be assigned a truth value (measurement) which expresses the accuracy of the representation. Examples of __Models__ include maps, blueprints, simulations, mathematical models, beliefs and claims.
 * __World State__: Given that the __Information__ in an __Environment__ may change with respect to some parameter (for example, time), __World State__ defines a static snapshot of the __Information__ within an __Environment__. In other words, a __World State__ is an __Environment__ where all __Information__ is held constant.
-* __World Model__*: An __Actor__'s internal __Model__ of its __World__. 
+* __World Model__: An Agent's internal __Model__ of its __World__. 
 * __Action__: An __Event__ in which __Information__ exits an Agent.
 * __Action Space__: The set of all __Actions__ that a particular Agent may perform. All __Actions__ performed by an Agent are sampled from its __Action Space__.
-* __Value__*: An __Actor__'s expression of preference between two __World States__. __Value__ may favour either __State__, or may reflect indifference. __Value__ is not intrinsic, and cannot be specified in the absence of an __Actor__.
+* __Value__: An Agent's expression of preference between two __World States__. __Value__ may favour either __State__, or may reflect indifference. __Value__ is not intrinsic, and cannot be specified in the absence of an __Actor__.
 * __Valuation__: The process of assigning a __Value__.
 * [__Reasonable__/__Unreasonable__](Reasonable.md)
-
-
-\* Marked for future revision.

--- a/Lexicon.md
+++ b/Lexicon.md
@@ -4,19 +4,20 @@
 * __Bit String__: A sequence of __Bits__ of arbitrary length $$ B^n := (b_k)_{k=0}^n , \  k \in \mathbb{N} $$.
 * __Vulcan Set__: The set of all __Bit Strings__ of infinite length $$ \mathbb{V} := \{ B_0^{\infty}, B_1^{\infty}, \dots, B_{\infty}^{\infty} \} , \ B_i^{\infty} \neq B_j^{\infty} $$.
 * __Information__: Anything that can be encoded into a __Bit String__.
-* __Environment__: __Information__ that is defined relative to a particular __Agent__. It is seperated from an __Agent__ by an __Agent Boundary__, and encompasses all content needed to process any relevant __Actions__ and __Observations__.
+* __Environment__: __Information__ that is defined relative to a particular __Actor__. It is seperated from an __Actor__ by an __Actor Boundary__, and encompasses all content needed to process any relevant __Events__.
 * __World__: Synonymous with __Environment__.
-* __Agent__: A __System__ that interacts with an __Environment__. It can consume zero or more __Observations__, and perform zero or more __Actions__. The decision of which __Actions__ to perform is made based on the __Agent's__ beliefs.
-* __Agent Boundary__: The surface that separates an __Agent__ from its __Environment__.
-* __Observation__: __Information__ that crosses the __Agent Boundary__, entering the __Agent__.
-* __Observation Space__: The set of all __Observations__ that a particular __Agent__ may observe. All __Observations__ perceived by an __Agent__ are sampled from its __Observation Space__.
+* __Actor__: __Information__ that interacts with an __Environment__ through __Events__.
+* __Actor Boundary__: The surface that separates an __Actor__ from its __Environment__.
+* __Event__: __Information__ that crosses the __Actor Boundary__.
+* __Observation__: An __Event__ in which __Information__ enters an Agent.
+* __Observation Space__: The set of all __Observations__ that a particular Agent may observe. All __Observations__ perceived by an Agent are sampled from its __Observation Space__.
 * __Object__: A set of correlated __Observations__.
 * __System__: An __Object__ composed of correlated member __Objects__.
 * __Model__: A __System__ that represents another __System__. It can be assigned a truth value (measurement) which expresses the accuracy of the representation. Examples of __Models__ include maps, blueprints, simulations, mathematical models, beliefs and claims.
 * __World State__: Given that the __Information__ in an __Environment__ may change with respect to some parameter (for example, time), __World State__ defines a static snapshot of the __Information__ within an __Environment__. In other words, a __World State__ is an __Environment__ where all __Information__ is held constant.
-* __World Model__: An __Agent__'s internal __Model__ of its __World__.
-* __Action__: __Information__ that crosses the __Agent Boundary__, exiting the __Agent__.
-* __Action Space__: The set of all __Actions__ that a particular __Agent__ may perform. All __Actions__ performed by an __Agent__ are sampled from its __Action Space__.
-* __Value__: An __Agent__'s expression of preference between two __World States__. __Value__ may favour either __State__, or may reflect indifference. __Value__ is not intrinsic, and cannot be specified in the absence of an __Agent__.
+* __World Model__: An __Actor__'s internal __Model__ of its __World__.
+* __Action__: An __Event__ in which __Information__ exits an Agent.
+* __Action Space__: The set of all __Actions__ that a particular Agent may perform. All __Actions__ performed by an Agent are sampled from its __Action Space__.
+* __Value__: An __Actor__'s expression of preference between two __World States__. __Value__ may favour either __State__, or may reflect indifference. __Value__ is not intrinsic, and cannot be specified in the absence of an __Actor__.
 * __Valuation__: The process of assigning a __Value__.
 * [__Reasonable__/__Unreasonable__](Reasonable.md)

--- a/Lexicon.md
+++ b/Lexicon.md
@@ -4,9 +4,9 @@
 * __Bit String__: A sequence of __Bits__ of arbitrary length $$ B^n := (b_k)_{k=0}^n , \  k \in \mathbb{N} $$.
 * __Vulcan Set__: The set of all __Bit Strings__ of infinite length $$ \mathbb{V} := \{ B_0^{\infty}, B_1^{\infty}, \dots, B_{\infty}^{\infty} \} , \ B_i^{\infty} \neq B_j^{\infty} $$.
 * __Information__: Anything that can be encoded into a __Bit String__.
-* __Environment__: __Information__ that is defined relative to a particular __Actor__. It is seperated from an __Actor__ by an __Actor Boundary__, and encompasses all content needed to process any relevant __Events__.
+* __Environment__: An __Object__ that is defined relative to a particular __Actor__. It is seperated from an __Actor__ by an __Actor Boundary__, and encompasses all content needed to process any relevant __Events__.
 * __World__: Synonymous with __Environment__.
-* __Actor__: __Information__ that interacts with an __Environment__ through __Events__.
+* __Actor__: An __Object__ that interacts with an __Environment__ through __Events__.
 * __Actor Boundary__: The surface that separates an __Actor__ from its __Environment__.
 * __Event__: __Information__ that crosses the __Actor Boundary__.
 * __Observation__: An __Event__ in which __Information__ enters an Agent.

--- a/Lexicon.md
+++ b/Lexicon.md
@@ -6,7 +6,7 @@
 * __Information__: Anything that can be encoded into a __Bit String__.
 * __Environment__: An __Object__ that is defined relative to a particular __Actor__. It is seperated from an __Actor__ by an __Actor Boundary__, and encompasses all content needed to process any relevant __Events__.
 * __World__: Synonymous with __Environment__.
-* __Actor__: An __Object__ that interacts with an __Environment__ through __Events__.
+* __Actor__: An __Object__ that interacts with an __Environment__ through __Events__. The difference between an __Actor__ and an __Object__ lies in its relevancy to a particular __Event__ (__Actors__ being relevant). The interpretation of the __Event__ crystallizes what is considered an __Actor__.
 * __Actor Boundary__: The surface that separates an __Actor__ from its __Environment__.
 * __Event__: __Information__ that crosses the __Actor Boundary__.
 * __Observation__: An __Event__ in which __Information__ enters an Agent.
@@ -15,9 +15,12 @@
 * __System__: An __Object__ composed of correlated member __Objects__.
 * __Model__: A __System__ that represents another __System__. It can be assigned a truth value (measurement) which expresses the accuracy of the representation. Examples of __Models__ include maps, blueprints, simulations, mathematical models, beliefs and claims.
 * __World State__: Given that the __Information__ in an __Environment__ may change with respect to some parameter (for example, time), __World State__ defines a static snapshot of the __Information__ within an __Environment__. In other words, a __World State__ is an __Environment__ where all __Information__ is held constant.
-* __World Model__: An __Actor__'s internal __Model__ of its __World__.
+* __World Model__*: An __Actor__'s internal __Model__ of its __World__. 
 * __Action__: An __Event__ in which __Information__ exits an Agent.
 * __Action Space__: The set of all __Actions__ that a particular Agent may perform. All __Actions__ performed by an Agent are sampled from its __Action Space__.
-* __Value__: An __Actor__'s expression of preference between two __World States__. __Value__ may favour either __State__, or may reflect indifference. __Value__ is not intrinsic, and cannot be specified in the absence of an __Actor__.
+* __Value__*: An __Actor__'s expression of preference between two __World States__. __Value__ may favour either __State__, or may reflect indifference. __Value__ is not intrinsic, and cannot be specified in the absence of an __Actor__.
 * __Valuation__: The process of assigning a __Value__.
 * [__Reasonable__/__Unreasonable__](Reasonable.md)
+
+
+\* Marked for future revision.


### PR DESCRIPTION
Based on our discussion on 15-10-18, I'd like to reopen #28 and define it in terms of Actor (#40). This was something @macterra and I discussed a while back. 

The core of this changeset is to replace the current definition of __Agent__ with the weaker __Actor__. We then define __Events__, which are an __Actor's__ rendition of __Actions__ and __Observations__. I have explicitly left out the definition of an __Agent__ for a future PR.

This is a fairly big changeset, so please be pedantic 🖖 I'm hoping it will resolve some confusion and lay the groundwork to discuss Agency in the future.