### PR TITLE
Reference Agents

### DIFF
--- a/_lexicon/preference.md
+++ b/_lexicon/preference.md
@@ -4,13 +4,13 @@ title: Preference
 description:  An Agent's expression of predilection between two __World States__. __Preference__ may favour either __State__, or may reflect indifference. __Preference__ is not intrinsic, and cannot be specified in the absence of an Agent. 
 ---
 
-Given an Agent's __Preference__ system $$ s $$, __Preference__ is formulated as $$
+Given an Agent's __Preference__ system $$ s_A $$, __Preference__ is formulated as $$
 \begin{equation}
-V(s, w_1, w_2) = \left\{
+P(s_A, w_{A,1}, w_{A,2}) = \left\{
 \begin{array}{cl}
-0 & w_1 \ {\rm and} \ w_2 \ {\rm of \ equal \ value}\\
-1 & w_1 \ {\rm of \ greater \ value}\\
--1 & w_2 \ {\rm of \ greater \ value}
+0 & w_{A,1} \ {\rm and} \ w_{A,2} \ {\rm of \ equal \ value}\\
+1 & w_{A,1} \ {\rm of \ greater \ value}\\
+-1 & w_{A,2} \ {\rm of \ greater \ value}
 \end{array}
 \right.
 \end{equation}

--- a/_lexicon/value.md
+++ b/_lexicon/value.md
@@ -9,3 +9,5 @@ Given an Agent's __Value__ system $$ s_A $$ and __World Model__ $$ W_A $$ with $
 V(s_A, w_{A,k}) = \frac{1}{N_{W,A} - 1} \sum_{i = 1}^{N_{W,A}} P(s, w_{A,k}, w_{A,i}) 
 \end{equation}
 $$
+
+Note that __Value__ is an ordinal metric as opposed to a cardinal one.

--- a/_lexicon/value.md
+++ b/_lexicon/value.md
@@ -4,8 +4,8 @@ title: Value
 description:  A measurement of the aggregate __Preference__ of a particular __World State__.
 ---
 
-Given Agent __Value__ system $$ s $$ and __World__ $$ W $$ with $$ N_W$$ __States__, __Value__ is defined as $$ 
+Given an Agent's __Value__ system $$ s_A $$ and __World Model__ $$ W_A $$ with $$ N_{W,A} $$ __States__, __Value__ is defined as $$ 
 \begin{equation}
-C(s, w_k) = \frac{1}{N_W - 1} \sum_{i = 1}^{N_W} V(s, w_k, w_i) 
+V(s_A, w_{A,k}) = \frac{1}{N_{W,A} - 1} \sum_{i = 1}^{N_{W,A}} P(s, w_{A,k}, w_{A,i}) 
 \end{equation}
 $$

--- a/_lexicon/world-model.md
+++ b/_lexicon/world-model.md
@@ -1,5 +1,5 @@
 ---
 layout: post
 title: World Model
-description:  An Agent's internal __Model__ of its __World__.
+description:  An Agent's internal __Model__ of its __World__. Denoted $$ W_A $$ where $$ A $$ is the reference Agent.
 ---

--- a/_lexicon/world-state.md
+++ b/_lexicon/world-state.md
@@ -4,4 +4,4 @@ title: World State
 description:  Given that the __Information__ in an __Environment__ may change with respect to some parameter (for example, time), __World State__ defines a static snapshot of the __Information__ within an __Environment__. In other words, a __World State__ is an __Environment__ where all __Information__ is held constant. Denoted $$ w \in W $$. When used with a reference Agent, $$ w_A \in W_A $$, __World State__ refers to a static snapshot of an Agent's __World Model__ as opposed to the __World__ itself.
 ---
 
-A __World State__ can be suffixed with descriptors which detail its properties. For example, a __World State__ containing $10 can be written as $$ w_A(\$10) $$
+A __World State__ can be suffixed with descriptors which detail its properties. For example, a __World State__ containing $10 can be written as $$ w_A(\$10) $$.

--- a/_lexicon/world-state.md
+++ b/_lexicon/world-state.md
@@ -3,3 +3,5 @@ layout: post
 title: World State
 description:  Given that the __Information__ in an __Environment__ may change with respect to some parameter (for example, time), __World State__ defines a static snapshot of the __Information__ within an __Environment__. In other words, a __World State__ is an __Environment__ where all __Information__ is held constant. Denoted $$ w \in W $$. When used with a reference Agent, $$ w_A \in W_A $$, __World State__ refers to a static snapshot of an Agent's __World Model__ as opposed to the __World__ itself.
 ---
+
+A __World State__ can be suffixed with descriptors which detail its properties. For example, a __World State__ containing $10 can be written as $$ w_A(\$10) $$

--- a/_lexicon/world-state.md
+++ b/_lexicon/world-state.md
@@ -1,5 +1,5 @@
 ---
 layout: post
 title: World State
-description:  Given that the __Information__ in an __Environment__ may change with respect to some parameter (for example, time), __World State__ defines a static snapshot of the __Information__ within an __Environment__. In other words, a __World State__ is an __Environment__ where all __Information__ is held constant. Denoted $$ w \in W $$.
+description:  Given that the __Information__ in an __Environment__ may change with respect to some parameter (for example, time), __World State__ defines a static snapshot of the __Information__ within an __Environment__. In other words, a __World State__ is an __Environment__ where all __Information__ is held constant. Denoted $$ w \in W $$. When used with a reference Agent, $$ w_A \in W_A $$, __World State__ refers to a static snapshot of an Agent's __World Model__ as opposed to the __World__ itself.
 ---


### PR DESCRIPTION
1. There were some typos in the Preference and Value formulas, which I fixed.
1. I wanted to encompass the idea that many times when we talk about World States, what we're really talking about is the State of a particular Agent's World Model, as opposed to the abstract World State itself.  I'm suggesting that whenever we subscript a World State with a particular Agent name, we are talking about the World Model State relative to that Agent. I propagated this change throughout Value and Preference as well.